### PR TITLE
FIX: question wrong timezone date

### DIFF
--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -262,7 +262,6 @@ export const submitQuestion = async (param: SubmitQuestionArgs) => {
         type: 'date',
         date: {
           start: new Date().toISOString(),
-          time_zone: 'Asia/Jakarta',
         },
       },
     },


### PR DESCRIPTION
Closes #35

It's showing the correct date now
![CleanShot 2023-10-11 at 19 34 35@2x](https://github.com/mazipan/tanyaaja/assets/55318172/1f64af54-7aeb-4dce-a059-7dd917cc1fb8)

would appreciate it if you can add hacktoberfest tag :p @mazipan 