### PR TITLE
FIX: Add Loader in Private Route + Header

### DIFF
--- a/src/app/account/layout.tsx
+++ b/src/app/account/layout.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+
+import { Loader2 } from 'lucide-react'
 
 import { useAuth } from '@/components/FirebaseAuth'
 import { getFirebaseAuth } from '@/lib/firebase'
@@ -17,14 +18,17 @@ export default function PrivateLayout({
   const { isLogin, isLoading } = useAuth(auth)
 
   // Redirect back to /login --> if the session is not found
-  useEffect(() => {
-    if (!isLoading) {
-      if (!isLogin) {
-        router.push('/login')
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLogin, isLoading, router])
-
-  return <main className="w-full container py-8">{children}</main>
+  if (!isLoading && !isLogin) {
+    router.push('/login')
+  }
+  // if there no login and user alredy login then render the main content
+  if (!isLoading && isLogin) {
+    return <main className="w-full container py-8">{children}</main>
+  }
+  // if the condition above didnt fullfill then we expect still loading
+  return (
+    <main className="w-full container h-[50vh]  my-auto flex justify-center items-center py-8">
+      <Loader2 className="animate-spin" size={40} />
+    </main>
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,7 +44,7 @@ export default function Home() {
 
           <div className="w-full flex gap-2 mt-8 flex-col xl:flex-row">
             <Button className="flex gap-2 items-center" size="lg" asChild>
-              <Link href="/login">
+              <Link href="/account">
                 Mulai dengan cepat
                 <ArrowRightIcon className="w-6 h-6" />
               </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,6 +12,7 @@ import {
 } from '@radix-ui/react-icons'
 
 import { signOut } from 'firebase/auth'
+import { Loader2 } from 'lucide-react'
 
 import { destroyActiveSession } from '@/lib/api'
 import { getFirebaseAuth } from '@/lib/firebase'
@@ -168,7 +169,9 @@ export function Header() {
               </Button>
             )}
           </>
-        ) : null}
+        ) : (
+          <Loader2 className="animate-spin" />
+        )}
 
         <ThemeSwitcher />
       </div>


### PR DESCRIPTION
Closes #38 

Add loader on initial load / first load to handle delayed load authenticated user 

oninitial load when user already authenticated user Not redirecting to login screen but got loading indicator

[fc68d3fc-e8d4-4546-af9e-c9ff44bfbf78.webm](https://github.com/mazipan/tanyaaja/assets/94950541/1aeabab3-d0a9-4076-adb6-485f1221bbe2)




