### PR TITLE
feat: add account visibility reminder component

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/components/FirebaseAuth'
 import { Separator } from '@/components/ui/separator'
 import { getFirebaseAuth, trackEvent } from '@/lib/firebase'
 import { Question } from '@/lib/types'
+import { AccountVisibilityReminder } from '@/modules/AccountSettings/AccountVisibilityReminder'
 import { QuestionPanel } from '@/modules/AccountSettings/QuestionCard'
 import { QuestionLoader } from '@/modules/AccountSettings/QuestionLoader'
 import { QuestionResponsive } from '@/modules/AccountSettings/QuestionPreview/QuestionResponsive'
@@ -100,6 +101,12 @@ export default function Account() {
           </>
         )}
       </div>
+
+      {!isLoadingOwner && (
+        <AccountVisibilityReminder
+          show={dataOwner ? !dataOwner.data.public : false}
+        />
+      )}
 
       <QuestionResponsive
         isOpen={isOpenDialog}

--- a/src/app/account/settings/page.tsx
+++ b/src/app/account/settings/page.tsx
@@ -42,6 +42,7 @@ import { useToast } from '@/components/ui/use-toast'
 import { BASEURL, checkTheSlugOwner, patchUpdateUser } from '@/lib/api'
 import { getFirebaseAuth, trackEvent } from '@/lib/firebase'
 import { DEFAULT_AVATAR, randomizeAvatar } from '@/lib/utils'
+import { AccountVisibilityReminder } from '@/modules/AccountSettings/AccountVisibilityReminder'
 import { useOwner } from '@/queries/useQueries'
 
 const auth = getFirebaseAuth()
@@ -87,6 +88,7 @@ export default function Account() {
   const watchSlug = form.watch('slug')
   const watchImage = form.watch('image')
   const watchName = form.watch('name')
+  const watchPublic = form.watch('public')
 
   async function onSubmit(data: FormValues) {
     trackEvent('click update account info')
@@ -258,26 +260,31 @@ export default function Account() {
                 ) : null}
               </div>
 
-              <FormField
-                control={form.control}
-                name="public"
-                render={({ field }) => (
-                  <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
-                    <div className="space-y-0.5">
-                      <FormLabel>Bisa dicari publik?</FormLabel>
-                      <FormDescription>
-                        Pengguna anonim dapat mencari akunmu lewat laman eksplor
-                      </FormDescription>
-                    </div>
-                    <FormControl>
-                      <Switch
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                  </FormItem>
-                )}
-              />
+              <div className="flex flex-col gap-4">
+                <FormField
+                  control={form.control}
+                  name="public"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                      <div className="space-y-0.5">
+                        <FormLabel>Bisa dicari publik?</FormLabel>
+                        <FormDescription>
+                          Pengguna anonim dapat mencari akunmu lewat laman
+                          eksplor
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <AccountVisibilityReminder show={!watchPublic} />
+              </div>
 
               <Card className="border-red-600">
                 <CardHeader>

--- a/src/app/account/settings/page.tsx
+++ b/src/app/account/settings/page.tsx
@@ -42,7 +42,6 @@ import { useToast } from '@/components/ui/use-toast'
 import { BASEURL, checkTheSlugOwner, patchUpdateUser } from '@/lib/api'
 import { getFirebaseAuth, trackEvent } from '@/lib/firebase'
 import { DEFAULT_AVATAR, randomizeAvatar } from '@/lib/utils'
-import { AccountVisibilityReminder } from '@/modules/AccountSettings/AccountVisibilityReminder'
 import { useOwner } from '@/queries/useQueries'
 
 const auth = getFirebaseAuth()
@@ -88,7 +87,6 @@ export default function Account() {
   const watchSlug = form.watch('slug')
   const watchImage = form.watch('image')
   const watchName = form.watch('name')
-  const watchPublic = form.watch('public')
 
   async function onSubmit(data: FormValues) {
     trackEvent('click update account info')
@@ -282,8 +280,6 @@ export default function Account() {
                     </FormItem>
                   )}
                 />
-
-                <AccountVisibilityReminder show={!watchPublic} />
               </div>
 
               <Card className="border-red-600">

--- a/src/modules/AccountSettings/AccountVisibilityReminder.tsx
+++ b/src/modules/AccountSettings/AccountVisibilityReminder.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from '@/components/ui/toast'
+
+const ONE_WEEK = 604_800_000
+const STORAGE_KEY = 'last-reminder'
+
+export const AccountVisibilityReminder = ({ show }: { show: boolean }) => {
+  const [isShown, setIsShown] = useState(show)
+
+  useEffect(() => {
+    const lastReminder = localStorage.getItem(STORAGE_KEY)
+    const now = new Date().getTime()
+
+    if (!lastReminder) {
+      setIsShown(show)
+
+      return
+    }
+
+    const lastReminderTime = Number.parseInt(lastReminder, 10)
+    if (now - ONE_WEEK >= lastReminderTime) {
+      setIsShown(show)
+    }
+  }, [show])
+
+  const handleReminderClose = () => {
+    const now = new Date().getTime()
+
+    localStorage.setItem(STORAGE_KEY, now.toString())
+
+    setIsShown(false)
+  }
+
+  return (
+    <ToastProvider duration={Infinity}>
+      <Toast open={isShown} onOpenChange={() => setIsShown(false)}>
+        <div className="flex flex-col gap-4">
+          <ToastTitle>Akun tidak publik</ToastTitle>
+          <ToastDescription>
+            Akun Anda tidak dapat dicari oleh pengguna anonim pada halaman
+            eksplor sampai Anda mengubah akun menjadi publik.
+          </ToastDescription>
+        </div>
+
+        <ToastClose onClick={handleReminderClose} />
+      </Toast>
+
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/src/modules/AccountSettings/AccountVisibilityReminder.tsx
+++ b/src/modules/AccountSettings/AccountVisibilityReminder.tsx
@@ -1,6 +1,9 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+import { Info } from 'lucide-react'
 
 import {
   Toast,
@@ -15,7 +18,7 @@ const ONE_WEEK = 604_800_000
 const STORAGE_KEY = 'last-reminder'
 
 export const AccountVisibilityReminder = ({ show }: { show: boolean }) => {
-  const [isShown, setIsShown] = useState(show)
+  const [isShown, setIsShown] = useState(false)
 
   useEffect(() => {
     const lastReminder = localStorage.getItem(STORAGE_KEY)
@@ -43,13 +46,20 @@ export const AccountVisibilityReminder = ({ show }: { show: boolean }) => {
 
   return (
     <ToastProvider duration={Infinity}>
-      <Toast open={isShown} onOpenChange={() => setIsShown(false)}>
-        <div className="flex flex-col gap-4">
-          <ToastTitle>Akun tidak publik</ToastTitle>
-          <ToastDescription>
-            Akun Anda tidak dapat dicari oleh pengguna anonim pada halaman
-            eksplor sampai Anda mengubah akun menjadi publik.
-          </ToastDescription>
+      <Toast open={isShown} onOpenChange={handleReminderClose}>
+        <div className="flex items-start gap-4">
+          <Info className="w-12 h-auto" />
+
+          <div className="flex flex-col gap-2">
+            <ToastTitle className="leading-tight">Akun tidak publik</ToastTitle>
+            <ToastDescription>
+              Ubah akun Anda menjadi publik pada halaman{' '}
+              <Link href="/account/settings" className="underline">
+                pengaturan akun
+              </Link>{' '}
+              agar dapat dilihat oleh pengguna lain pada halaman eksplor.
+            </ToastDescription>
+          </div>
         </div>
 
         <ToastClose onClick={handleReminderClose} />


### PR DESCRIPTION
Closes #22 

## Description

This pull request adds reminder for account visibility settings in account settings page. It will be shown weekly whenever account visibility is not public.

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] Create `AccountVisibilityReminder` component
- [x] Create one week reminder logic
- [x] Hook the state with `public` value on the form
