### PR TITLE
FEAT: Move Private public button to the list

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
+    "@radix-ui/react-toggle": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@sindresorhus/slugify": "^2.2.1",
     "@tanstack/react-query": "^4.36.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ dependencies:
   '@radix-ui/react-toast':
     specifier: ^1.1.5
     version: 1.1.5(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-toggle':
+    specifier: ^1.0.3
+    version: 1.0.3(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-tooltip':
     specifier: ^1.0.7
     version: 1.0.7(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0)(react@18.2.0)
@@ -1560,6 +1563,29 @@ packages:
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.27)(react@18.2.0)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.27)(react@18.2.0)
       '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.27
+      '@types/react-dom': 18.2.12
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-toggle@1.0.3(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Pkqg3+Bc98ftZGsl60CLANXQBBQ4W3mTFS9EJvNxKMZ7magklKV69/id1mlAlOFDDfHvlCms0fx8fA4CMKDJHg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.27)(react@18.2.0)
       '@types/react': 18.2.27
       '@types/react-dom': 18.2.12
       react: 18.2.0

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,9 @@
     --accent: 60 4.8% 95.9%;
     --accent-foreground: 24 9.8% 10%;
 
+    --success: 116, 54%, 34%;
+    --success-foreground: 60 9.1% 97.8%;
+    
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 60 9.1% 97.8%;
 
@@ -56,6 +59,9 @@
 
     --accent: 12 6.5% 15.1%;
     --accent-foreground: 60 9.1% 97.8%;
+
+    --success: 116, 54%, 34%;
+    --success-foreground:60 9.1% 97.8%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 60 9.1% 97.8%;

--- a/src/components/PublicAccessToggler.tsx
+++ b/src/components/PublicAccessToggler.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import { Lock, Unlock } from 'lucide-react'
+
+import { Toggle } from '@/components/ui/toggle'
+import { trackEvent } from '@/lib/firebase'
+import { Question } from '@/lib/types'
+import { usePatchQuestionAsPublicOrPrivate } from '@/modules/AccountSettings/hooks/usePatchQuestionAsPublicOrPrivate'
+
+import { useToast } from './ui/use-toast'
+
+interface PublicAccessTogglerProps {
+  question: Question
+  disabled?: boolean // allow parent to override
+  onMutateSuccess?: (question: Question) => void
+}
+
+const PublicAccessToggler = ({
+  question,
+  disabled,
+  onMutateSuccess,
+}: PublicAccessTogglerProps) => {
+  const { toast } = useToast()
+
+  const patchQuestionAsPublicOrPrivateMutation =
+    usePatchQuestionAsPublicOrPrivate()
+
+  const handleTogglePrivacy = () => {
+    trackEvent('click toggle public access')
+
+    patchQuestionAsPublicOrPrivateMutation.mutate(question, {
+      onSuccess: () => {
+        onMutateSuccess?.(question)
+      },
+      onError: () => {
+        toast({
+          title: 'Gagal menyimpan perubahan',
+          description: `Gagal saat mencoba mengubah hak akses publik ke laman pertanyaan, coba sesaat lagi!`,
+        })
+      },
+    })
+  }
+
+  return (
+    <Toggle
+      variant="outline"
+      aria-label="Toggle Question Privacy"
+      className="data-[state=on]:bg-success"
+      defaultPressed={question?.public}
+      pressed={question?.public}
+      disabled={disabled ?? patchQuestionAsPublicOrPrivateMutation.isLoading}
+      onPressedChange={handleTogglePrivacy}
+    >
+      {question?.public ? (
+        <Unlock className="w-4 h-4" />
+      ) : (
+        <Lock className="w-4 h-4" />
+      )}
+    </Toggle>
+  )
+}
+
+export default PublicAccessToggler

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import * as React from 'react'
+import * as TogglePrimitive from '@radix-ui/react-toggle'
+
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const toggleVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        outline:
+          'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-10 px-3',
+        sm: 'h-9 px-2.5',
+        lg: 'h-11 px-5',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+Toggle.displayName = TogglePrimitive.Root.displayName
+
+export { Toggle, toggleVariants }

--- a/src/modules/AccountSettings/QuestionCard.tsx
+++ b/src/modules/AccountSettings/QuestionCard.tsx
@@ -76,8 +76,9 @@ export const QuestionPanel = ({
       {question ? (
         <>
           <CardHeader>
-            <CardTitle className="text-2xl">Pertanyaan #{index}</CardTitle>
-            <CardDescription className="flex gap-1 items-center">
+            <div className="flex justify-between">
+              <CardTitle className="text-2xl">Pertanyaan #{index}</CardTitle>
+
               <Toggle
                 defaultPressed={question?.public}
                 pressed={question?.public}
@@ -93,6 +94,14 @@ export const QuestionPanel = ({
                   <Lock className="w-4 h-4" />
                 )}
               </Toggle>
+            </div>
+
+            <CardDescription className="flex gap-1 items-center">
+              {question.public ? (
+                <Unlock className="w-4 h-4" />
+              ) : (
+                <Lock className="w-4 h-4" />
+              )}
               <span className="text-sm">
                 {question.public
                   ? 'Bisa diakses publik'

--- a/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { useToast } from '@/components/ui/use-toast'
-import { patchQuestionAsDone, patchQuestionAsPublicOrPrivate } from '@/lib/api'
+import { patchQuestionAsDone } from '@/lib/api'
 import { trackEvent } from '@/lib/firebase'
 import { Question } from '@/lib/types'
 
@@ -47,51 +47,8 @@ export const ButtonAction = ({
     }
   }
 
-  const togglePublicPrivate = async (question: Question) => {
-    trackEvent('click toggle public access')
-    if (user) {
-      try {
-        setIsSubmitting(true)
-        await patchQuestionAsPublicOrPrivate(
-          question.uuid,
-          question.public ? 'PRIVATE' : 'PUBLIC',
-          user,
-        )
-
-        toast({
-          title: 'Berhasil mengubah akses ke pertanyaan',
-          description: `Berhasil mengubah akses publik ke laman detail pertanyaan!`,
-        })
-
-        setIsSubmitting(false)
-        onRefetch?.()
-        setTimeout(() => {
-          onOpenChange(false)
-        }, 500)
-      } catch (error) {
-        setIsSubmitting(false)
-        toast({
-          title: 'Gagal menyimpan perubahan',
-          description: `Gagal saat mencoba mengubah hak akses publik ke laman pertanyaan, coba sesaat lagi!`,
-        })
-      }
-    }
-  }
-
   return (
     <div className="flex flex-col md:flex-row gap-2">
-      <Button
-        type="button"
-        disabled={isSubmitting}
-        variant={question?.public ? 'outline' : 'destructive'}
-        onClick={() => {
-          if (question) {
-            togglePublicPrivate(question)
-          }
-        }}
-      >
-        {question?.public ? 'Larang akses publik' : 'Beri akses publik'}
-      </Button>
       <Button
         type="button"
         disabled={isSubmitting}

--- a/src/modules/AccountSettings/hooks/usePatchQuestionAsPublicOrPrivate.ts
+++ b/src/modules/AccountSettings/hooks/usePatchQuestionAsPublicOrPrivate.ts
@@ -1,0 +1,36 @@
+import { useMutation } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import { useAuth } from '@/components/FirebaseAuth'
+import { patchQuestionAsPublicOrPrivate } from '@/lib/api'
+import { getFirebaseAuth } from '@/lib/firebase'
+import { Question } from '@/lib/types'
+
+const payloadSchema = z.object({
+  uuid: z.string(),
+  public: z.boolean(),
+})
+
+const auth = getFirebaseAuth()
+
+export const usePatchQuestionAsPublicOrPrivate = () => {
+  const { user } = useAuth(auth)
+
+  const mutation = useMutation({
+    mutationFn: (variable?: Question | null) => {
+      // Validate
+      const validatedVariable = payloadSchema.parse(variable)
+
+      if (!user) throw new Error('User is not logged in')
+
+      // Request
+      return patchQuestionAsPublicOrPrivate(
+        validatedVariable.uuid,
+        validatedVariable.public ? 'PRIVATE' : 'PUBLIC',
+        user,
+      )
+    },
+  })
+
+  return mutation
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,6 +30,10 @@ module.exports = {
           DEFAULT: 'hsl(var(--secondary))',
           foreground: 'hsl(var(--secondary-foreground))',
         },
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          foreground: 'hsl(var(--success-foreground))',
+        },
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',


### PR DESCRIPTION
Closes #56

## Description
Move toggle private public to the list, all toggle performed independently 

each list item have toggle button that triggers Public / private
<!-- Describe your implementation plan and approach -->

![2023-10-14 13 51 07](https://github.com/mazipan/tanyaaja/assets/8034141/68c2324a-8b23-4f70-b415-9853b63e11bb)


## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [ ] (task 1)
- [ ] (task 2)
- [ ] (task 3)
