### PR TITLE
FIX: Overflowed Alert Layout on Setting Notification Page

### DIFF
--- a/src/app/account/settings/notification/page.tsx
+++ b/src/app/account/settings/notification/page.tsx
@@ -32,7 +32,7 @@ export default function SettingOgImage() {
   }, [])
 
   return (
-    <main className="w-full container py-8">
+    <>
       <div className="w-full space-y-0.5">
         <h2 className="text-2xl font-bold tracking-tight">
           Setelan Notifikasi
@@ -43,12 +43,16 @@ export default function SettingOgImage() {
       </div>
 
       <Separator className="my-6" />
-      <Tabs defaultValue="telegram">
-        <TabsList className="mb-2">
-          <TabsTrigger value="telegram">Telegram</TabsTrigger>
-        </TabsList>
+      <Tabs defaultValue="telegram" className="space-y-6">
+        <div className="-mx-8 -mb-2 overflow-y-auto">
+          <div className="px-8 pb-2 inline-block align-middle">
+            <TabsList className="gap-2">
+              <TabsTrigger value="telegram">Telegram</TabsTrigger>
+            </TabsList>
+          </div>
+        </div>
         <TabsContent value="telegram">
-          <div className="w-full space-y-0.5">
+          <div className="mb-6 space-y-0.5">
             <h3 className="text-xl font-bold tracking-tight">
               Notifikasi ke Telegram
             </h3>
@@ -64,6 +68,6 @@ export default function SettingOgImage() {
           />
         </TabsContent>
       </Tabs>
-    </main>
+    </>
   )
 }

--- a/src/modules/AccountSettings/SettingNotif/SettingTelegram.tsx
+++ b/src/modules/AccountSettings/SettingNotif/SettingTelegram.tsx
@@ -132,98 +132,79 @@ export default function SettingTelegram({
   }, [existing])
 
   return (
-    <div className="w-full flex flex-col space-y-8 lg:flex-row lg:space-x-12 lg:space-y-0 mt-4">
-      <section className="flex-1 lg:max-w-2xl">
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-            <FormField
-              control={form.control}
-              name="username"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Username Telegram</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="Isi dengan username Telegram"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Tidak perlu menambahkan karakter @ di depan username
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="lg:max-w-2xl">
+        <FormField
+          control={form.control}
+          name="username"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Username Telegram</FormLabel>
+              <FormControl>
+                <Input placeholder="Isi dengan username Telegram" {...field} />
+              </FormControl>
+              <FormDescription>
+                Tidak perlu menambahkan karakter @ di depan username
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-            <Alert className="mb-4">
-              <Info className="h-4 w-4" />
-              <AlertTitle>Tips!</AlertTitle>
-              <AlertDescription>
-                <ul className="list-disc">
-                  <li className="m-0">
-                    <div className="flex items-center gap-2">
-                      Kamu perlu mengisi username untuk mendapatkan chat id
-                    </div>
-                  </li>
-                  <li className="m-0">
-                    <div className="flex items-center gap-2">
-                      Kirimkan perintah{' '}
-                      <code className="text-blue-400">/start</code> ke{' '}
-                      <code className="text-blue-400">@tanyaajabot</code> di
-                      Telegram
-                    </div>
-                  </li>
-                  <li className="m-0">
-                    <div className="flex items-center gap-2">
-                      Tekan tombol "Ambil Chat ID" setelah mengirimkan perintah{' '}
-                      <code className="text-blue-400">/start</code>
-                    </div>
-                  </li>
-                </ul>
-              </AlertDescription>
-            </Alert>
+        <Alert className="my-6">
+          <Info className="h-4 w-4" />
+          <AlertTitle className="mb-4">Tips!</AlertTitle>
+          <AlertDescription>
+            <ul className="list-disc list-outside space-y-1.5">
+              <li>Kamu perlu mengisi username untuk mendapatkan chat id</li>
+              <li>
+                Kirimkan perintah <code className="text-blue-400">/start</code>{' '}
+                ke <code className="text-blue-400">@tanyaajabot</code> di
+                Telegram
+              </li>
+              <li>
+                Tekan tombol "Ambil Chat ID" setelah mengirimkan perintah{' '}
+                <code className="text-blue-400">/start</code>
+              </li>
+            </ul>
+          </AlertDescription>
+        </Alert>
 
-            <div className="flex gap-2 items-end flex-wrap">
-              <div className="flex-1">
-                <FormField
-                  control={form.control}
-                  name="chatId"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Chat ID Target</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder="Isi dengan target Chat ID"
-                          disabled={!watchUsername}
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <div className="w-[150px]">
+        <FormField
+          control={form.control}
+          name="chatId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Chat ID Target</FormLabel>
+              <div className="flex gap-2">
+                <FormControl className="flex-1">
+                  <Input
+                    placeholder="Isi dengan target Chat ID"
+                    disabled={!watchUsername}
+                    {...field}
+                  />
+                </FormControl>
                 <Button
                   type="button"
                   variant="outline"
                   disabled={!watchUsername || isSubmitting || isLoading}
                   onClick={handleCheckChatId}
+                  className="shrink-0"
                 >
                   Ambil Chat ID
                 </Button>
               </div>
-            </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-            <div className="flex gap-2 items-center">
-              <Button type="submit" disabled={isSubmitting || isLoading}>
-                {isSubmitting ? 'Processing' : 'Simpan Perubahan'}
-              </Button>
-            </div>
-          </form>
-        </Form>
-      </section>
-    </div>
+        <div className="mt-8 flex gap-2 items-center">
+          <Button type="submit" disabled={isSubmitting || isLoading}>
+            {isSubmitting ? 'Processing' : 'Simpan Perubahan'}
+          </Button>
+        </div>
+      </form>
+    </Form>
   )
 }


### PR DESCRIPTION
Closes #61 

## Description
Fix overflowed alert box on setting notification page on smaller screen issue.
<img width="288" alt="Screenshot 2023-10-14 at 16 10 54" src="https://github.com/mazipan/tanyaaja/assets/128473060/880e896c-167d-4648-b409-47ca4415094e">

While I'm at it, I also did some styling changes and fix styling issues on setting notification page:
- Handle overflowed issue on tab list. Below is the example of how it looks like with long tab list

https://github.com/mazipan/tanyaaja/assets/128473060/68d64fae-8559-47df-8eec-036b095b6478

<br>

- Handle layout shift issue when displaying error message on "Chat ID Target". The below image on the left shows the before fix, while the right one shows the after fix:
<img width="250" alt="Screenshot 2023-10-14 at 16 23 31" src="https://github.com/mazipan/tanyaaja/assets/128473060/c4239d1e-bb90-4073-881b-5f5ef6d142b4">
<img width="200" alt="Screenshot 2023-10-14 at 16 11 16" src="https://github.com/mazipan/tanyaaja/assets/128473060/61f8d413-c57e-4437-a799-f628183b49e8">

<br>

- Remove container padding so that the layout is consistent with other pages (e.g. `/account`, `/account/settings`). Also, modifying the gaps between element for consistency. Now, the page looks like below:
<img width="500" alt="Screenshot 2023-10-14 at 16 17 10" src="https://github.com/mazipan/tanyaaja/assets/128473060/61709371-275b-4f6d-9f2e-78aae98d4a82">
<img width="350" alt="Screenshot 2023-10-14 at 16 18 28" src="https://github.com/mazipan/tanyaaja/assets/128473060/02e59339-f824-4e40-9494-106dafea85a0">
