### PR TITLE
FIX: Styling Inconsistency Across Settings Pages

### DIFF
--- a/src/app/account/settings/notification/page.tsx
+++ b/src/app/account/settings/notification/page.tsx
@@ -46,7 +46,7 @@ export default function SettingOgImage() {
       <Tabs defaultValue="telegram" className="space-y-6">
         <div className="-mx-8 -mb-2 overflow-y-auto">
           <div className="px-8 pb-2 inline-block align-middle">
-            <TabsList className="gap-2">
+            <TabsList>
               <TabsTrigger value="telegram">Telegram</TabsTrigger>
             </TabsList>
           </div>

--- a/src/app/account/settings/og-image/page.tsx
+++ b/src/app/account/settings/og-image/page.tsx
@@ -42,13 +42,17 @@ export default function SettingOgImage() {
       </div>
 
       <Separator className="my-6" />
-      <Tabs defaultValue="simple-mode">
-        <TabsList className="mb-2">
-          <TabsTrigger value="simple-mode">Mode Sederhana</TabsTrigger>
-          <TabsTrigger value="advance-mode">Mode Rumit</TabsTrigger>
-        </TabsList>
+      <Tabs defaultValue="simple-mode" className="space-y-6">
+        <div className="-mx-8 -mb-2 overflow-y-auto">
+          <div className="px-8 pb-2 inline-block align-middle">
+            <TabsList>
+              <TabsTrigger value="simple-mode">Mode Sederhana</TabsTrigger>
+              <TabsTrigger value="advance-mode">Mode Rumit</TabsTrigger>
+            </TabsList>
+          </div>
+        </div>
         <TabsContent value="simple-mode">
-          <div className="w-full space-y-0.5">
+          <div className="mb-6 space-y-0.5">
             <h3 className="text-xl font-bold tracking-tight">Mode Sederhana</h3>
             <p className="text-sm text-muted-foreground">
               Atur OG Image dengan lebih mudah untuk pengguna awam
@@ -62,7 +66,7 @@ export default function SettingOgImage() {
           />
         </TabsContent>
         <TabsContent value="advance-mode">
-          <div className="w-full space-y-0.5">
+          <div className="mb-6 space-y-0.5">
             <h3 className="text-xl font-bold tracking-tight">Mode Rumit</h3>
             <p className="text-sm text-muted-foreground">
               Atur OG Image semaumu untuk pengguna yang familiar dengan coding

--- a/src/app/account/settings/page.tsx
+++ b/src/app/account/settings/page.tsx
@@ -171,50 +171,49 @@ export default function Account() {
 
       <Separator className="my-6" />
 
-      <div className="w-full flex flex-col space-y-8 lg:flex-row lg:space-x-12 lg:space-y-0">
-        <section className="flex-1 lg:max-w-2xl">
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Nama Publik</FormLabel>
-                    <FormControl>
-                      <Input placeholder="Nama publik" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      Nama ini akan ditampilkan di laman beranda publikmu. Kami
-                      akan menggunakan nama dari akun Google bila belum disetel.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="lg:max-w-2xl">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nama Publik</FormLabel>
+                <FormControl>
+                  <Input placeholder="Nama publik" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Nama ini akan ditampilkan di laman beranda publikmu. Kami akan
+                  menggunakan nama dari akun Google bila belum disetel.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-              <FormField
-                control={form.control}
-                name="image"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Alamat Avatar Publik</FormLabel>
-                    <FormControl>
-                      <Input placeholder="Alamat avatar publik" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      Avatar ini akan ditampilkan di laman beranda publikmu.
-                      Kami akan menggunakan gambar akun Google bila belum
-                      disetel.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+          <div className="mt-6 space-y-3">
+            <FormField
+              control={form.control}
+              name="image"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Alamat Avatar Publik</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Alamat avatar publik" {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Avatar ini akan ditampilkan di laman beranda publikmu. Kami
+                    akan menggunakan gambar akun Google bila belum disetel.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-              {watchImage ? (
-                <div className="flex items-center gap-2 ">
-                  <p>Preview:</p>
+            {watchImage ? (
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <p>Preview:</p>
+                <div className="flex items-center gap-2">
                   <ProfileAvatar
                     image={watchImage}
                     name={watchName}
@@ -226,142 +225,143 @@ export default function Account() {
                     onClick={() => {
                       form.setValue('image', randomizeAvatar())
                     }}
+                    className="shrink-0"
                   >
-                    <RefreshCw className="h-4 w-4 mr-2" />
+                    <RefreshCw className="h-4 w-4 mr-2 shrink-0" />
                     Pilih secara acak
                   </Button>
                 </div>
-              ) : null}
+              </div>
+            ) : null}
+          </div>
 
-              <FormField
-                control={form.control}
-                name="x_username"
-                render={({ field }) => (
+          <FormField
+            control={form.control}
+            name="x_username"
+            render={({ field }) => (
+              <FormItem className="mt-6">
+                <FormLabel>Username X (Twitter)</FormLabel>
+                <FormControl>
+                  <Input placeholder="@username" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Username ini akan ditampilkan di laman beranda publikmu.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="mt-6 space-y-3">
+            <FormField
+              control={form.control}
+              name="slug"
+              render={({ field }) => {
+                return (
                   <FormItem>
-                    <FormLabel>Username X (Twitter)</FormLabel>
+                    <FormLabel>Slug</FormLabel>
                     <FormControl>
-                      <Input placeholder="@username" {...field} />
+                      <Input placeholder="Slug publik" {...field} />
                     </FormControl>
                     <FormDescription>
-                      Username ini akan ditampilkan di laman beranda publikmu.
+                      Slug ini adalah alamat dari laman publikmu. Bisa diubah
+                      kapan saja, tapi dapat menyebabkan alamat lamamu tidak
+                      dapat dikunjungi lagi.
                     </FormDescription>
                     <FormMessage />
                   </FormItem>
-                )}
+                )
+              }}
+            />
+
+            {watchSlug !== '' ? (
+              <CopyButton
+                text={`${BASEURL}/p/${watchSlug}`}
+                withLabel
+                withInput
+                fullWidth
               />
+            ) : null}
+          </div>
 
-              <FormField
-                control={form.control}
-                name="slug"
-                render={({ field }) => {
-                  return (
-                    <FormItem>
-                      <FormLabel>Slug</FormLabel>
-                      <FormControl>
-                        <Input placeholder="Slug publik" {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        Slug ini adalah alamat dari laman publikmu. Bisa diubah
-                        kapan saja, tapi dapat menyebabkan alamat lamamu tidak
-                        dapat dikunjungi lagi.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )
-                }}
-              />
-
-              <div className="flex gap-2 items-center w-full">
-                {watchSlug !== '' ? (
-                  <CopyButton
-                    text={`${BASEURL}/p/${watchSlug}`}
-                    withLabel
-                    withInput
-                    fullWidth
-                  />
-                ) : null}
-              </div>
-
-              <div className="flex flex-col gap-4">
-                <FormField
-                  control={form.control}
-                  name="public"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
-                      <div className="space-y-0.5">
-                        <FormLabel>Bisa dicari publik?</FormLabel>
-                        <FormDescription>
-                          Pengguna anonim dapat mencari akunmu lewat laman
-                          eksplor
-                        </FormDescription>
-                      </div>
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <Card className="border-red-600">
-                <CardHeader>
-                  <CardTitle>Area Berbahaya!</CardTitle>
-
-                  <CardDescription>
-                    Aksi pada bagian ini dapat menghilangkan keseluruhan datamu
-                    yang ada di TanyaAja.in
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex gap-2 flex-wrap flex-col md:flex-row">
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      onClick={() => {
-                        toast({
-                          title:
-                            'Fitur "Hapus semua pertanyaan" belum tersedia',
-                          description: `Fitur masih dalam tahap pengembangan, pantau perkembangannya di GitHub dan Twitter!`,
-                        })
-                      }}
-                    >
-                      Hapus semua pertanyaan
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      onClick={() => {
-                        toast({
-                          title: 'Fitur "Hapus akun saya" belum tersedia',
-                          description: `Fitur masih dalam tahap pengembangan, pantau perkembangannya di GitHub dan Twitter!`,
-                        })
-                      }}
-                    >
-                      Hapus akun saya
-                    </Button>
+          <div className="mt-6 flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="public"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                  <div className="space-y-0.5">
+                    <FormLabel>Bisa dicari publik?</FormLabel>
+                    <FormDescription>
+                      Pengguna anonim dapat mencari akunmu lewat laman eksplor
+                    </FormDescription>
                   </div>
-                </CardContent>
-              </Card>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
 
-              <Button type="submit" disabled={isSubmitting || isLoadingOwner}>
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    <span>Processing...</span>
-                  </>
-                ) : (
-                  <>
-                    <span>Simpan Perubahan</span>
-                  </>
-                )}
-              </Button>
-            </form>
-          </Form>
-        </section>
-      </div>
+          <Card className="mt-6 border-red-600">
+            <CardHeader>
+              <CardTitle>Area Berbahaya!</CardTitle>
+
+              <CardDescription>
+                Aksi pada bagian ini dapat menghilangkan keseluruhan datamu yang
+                ada di TanyaAja.in
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex gap-2 flex-wrap flex-col md:flex-row">
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => {
+                    toast({
+                      title: 'Fitur "Hapus semua pertanyaan" belum tersedia',
+                      description: `Fitur masih dalam tahap pengembangan, pantau perkembangannya di GitHub dan Twitter!`,
+                    })
+                  }}
+                >
+                  Hapus semua pertanyaan
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => {
+                    toast({
+                      title: 'Fitur "Hapus akun saya" belum tersedia',
+                      description: `Fitur masih dalam tahap pengembangan, pantau perkembangannya di GitHub dan Twitter!`,
+                    })
+                  }}
+                >
+                  Hapus akun saya
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Button
+            type="submit"
+            disabled={isSubmitting || isLoadingOwner}
+            className="mt-8"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin shrink-0" />
+                <span>Menyimpan...</span>
+              </>
+            ) : (
+              'Simpan Perubahan'
+            )}
+          </Button>
+        </form>
+      </Form>
     </>
   )
 }

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -23,7 +23,7 @@ export function CopyButton({
   const [isCopied, setIsCopied] = useState(false)
 
   return (
-    <div className={`flex space-x-2 ${fullWidth ? 'w-full' : ''}`}>
+    <div className={`flex gap-2 ${fullWidth ? 'w-full' : ''}`}>
       {withInput ? <Input value={text} readOnly /> : null}
       <Button
         variant="outline"
@@ -38,9 +38,9 @@ export function CopyButton({
         }}
       >
         {isCopied ? (
-          <Check className="h-4 w-4" />
+          <Check className="h-4 w-4 shrink-0" />
         ) : (
-          <Copy className="h-4 w-4" />
+          <Copy className="h-4 w-4 shrink-0" />
         )}
         {withLabel ? (
           <>{isCopied ? <span>Tersalin</span> : <span>Salin</span>}</>

--- a/src/modules/AccountSettings/QuestionCard.tsx
+++ b/src/modules/AccountSettings/QuestionCard.tsx
@@ -55,8 +55,10 @@ export const QuestionPanel = ({
       {question ? (
         <>
           <CardHeader>
-            <div className="flex justify-between">
-              <CardTitle className="text-2xl">Pertanyaan #{index}</CardTitle>
+            <div className="flex justify-between gap-2">
+              <CardTitle className="text-2xl self-center leading-none">
+                Pertanyaan #{index}
+              </CardTitle>
 
               <PublicAccessToggler
                 question={question}

--- a/src/modules/AccountSettings/SettingNotif/SettingTelegram.tsx
+++ b/src/modules/AccountSettings/SettingNotif/SettingTelegram.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form'
 
 import { valibotResolver } from '@hookform/resolvers/valibot'
 import { User } from 'firebase/auth'
-import { Info } from 'lucide-react'
+import { Info, Loader2 } from 'lucide-react'
 import { maxLength, minLength, object, type Output, string } from 'valibot'
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -199,9 +199,16 @@ export default function SettingTelegram({
           )}
         />
 
-        <div className="mt-8 flex gap-2 items-center">
+        <div className="mt-8">
           <Button type="submit" disabled={isSubmitting || isLoading}>
-            {isSubmitting ? 'Processing' : 'Simpan Perubahan'}
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin shrink-0" />
+                <span>Menyimpan...</span>
+              </>
+            ) : (
+              'Simpan Perubahan'
+            )}
           </Button>
         </div>
       </form>

--- a/src/modules/AccountSettings/SettingOg/AdvanceMode.tsx
+++ b/src/modules/AccountSettings/SettingOg/AdvanceMode.tsx
@@ -121,117 +121,109 @@ export default function AdvanceMode({
   }, [existingOg])
 
   return (
-    <div className="w-full flex flex-col space-y-8 lg:flex-row lg:space-x-12 lg:space-y-0 mt-4">
-      <section className="flex-1 lg:max-w-2xl">
-        <Alert className="mb-4">
-          <Info className="h-4 w-4" />
-          <AlertTitle>Tips!</AlertTitle>
-          <AlertDescription>
-            <ul className="list-disc">
-              <li className="m-0">
-                <div>
-                  Kamu bisa mencoba kodemu di{' '}
-                  <Link
-                    href="https://og-playground.vercel.app/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="hover:underline flex items-center text-blue-400"
-                  >
-                    og-playground.vercel.app
-                    <MoveUpRight className="h-4 w-4" />
-                  </Link>
-                </div>
-              </li>
-              <li className="m-0">
-                <div>Gunakan ukuran 800x600 (width: 800px, height: 400px)</div>
-              </li>
-              <li className="m-0">
-                <div>
-                  Kamu bisa menggunakan{' '}
-                  <Link
-                    href="https://hypercolor.dev/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="hover:underline flex items-center text-blue-400"
-                  >
-                    hypercolor.dev
-                    <MoveUpRight className="h-4 w-4" />
-                  </Link>
-                  untuk inspirasi gradient
-                </div>
-              </li>
-              <li className="m-0">
-                <div>
-                  Kamu bisa menggunakan parameter{' '}
-                  <code className="text-blue-400">[question]</code> untuk
-                  menggantikan pertanyaan
-                </div>
-              </li>
-            </ul>
-          </AlertDescription>
-        </Alert>
+    <section className="lg:max-w-2xl space-y-6">
+      <Alert>
+        <Info className="h-4 w-4" />
+        <AlertTitle className="mb-4">Tips!</AlertTitle>
+        <AlertDescription>
+          <ul className="list-disc list-outside space-y-1.5">
+            <li>
+              Kamu bisa mencoba kodemu di{' '}
+              <Link
+                href="https://og-playground.vercel.app/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline inline-flex items-center text-blue-400"
+              >
+                og-playground.vercel.app
+                <MoveUpRight className="h-4 w-4 shrink-0" />
+              </Link>
+            </li>
+            <li>Gunakan ukuran 800x600 (width: 800px, height: 400px)</li>
+            <li>
+              Kamu bisa menggunakan{' '}
+              <Link
+                href="https://hypercolor.dev/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline inline-flex items-center text-blue-400"
+              >
+                hypercolor.dev
+                <MoveUpRight className="h-4 w-4 shrink-0" />
+              </Link>
+              untuk inspirasi gradient
+            </li>
+            <li>
+              Kamu bisa menggunakan parameter{' '}
+              <code className="text-blue-400">[question]</code> untuk
+              menggantikan pertanyaan
+            </li>
+          </ul>
+        </AlertDescription>
+      </Alert>
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-            <FormField
-              control={form.control}
-              name="publik"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>OG Image Laman Publik</FormLabel>
-                  <FormDescription>
-                    Kode ini akan digunakan untuk og image laman publik Anda.
-                  </FormDescription>
-                  <FormControl>
-                    <Textarea
-                      placeholder="Kode untuk OG image laman publik Anda"
-                      className="resize-y"
-                      rows={10}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name="publik"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>OG Image Laman Publik</FormLabel>
+                <FormDescription>
+                  Kode ini akan digunakan untuk og image laman publik Anda.
+                </FormDescription>
+                <FormControl>
+                  <Textarea
+                    placeholder="Kode untuk OG image laman publik Anda"
+                    className="resize-y"
+                    rows={10}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <FormField
-              control={form.control}
-              name="question"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>OG Image Laman Pertanyaan</FormLabel>
-                  <FormDescription>
-                    Kode ini akan digunakan untuk og image laman publik Anda.
-                  </FormDescription>
-                  <FormControl>
-                    <Textarea
-                      placeholder="Kode untuk OG image laman pertanyaan Anda"
-                      className="resize-y"
-                      rows={10}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            control={form.control}
+            name="question"
+            render={({ field }) => (
+              <FormItem className="mt-6">
+                <FormLabel>OG Image Laman Pertanyaan</FormLabel>
+                <FormDescription>
+                  Kode ini akan digunakan untuk og image laman publik Anda.
+                </FormDescription>
+                <FormControl>
+                  <Textarea
+                    placeholder="Kode untuk OG image laman pertanyaan Anda"
+                    className="resize-y"
+                    rows={10}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <Button type="submit" disabled={isSubmitting || isLoading}>
-              {isSubmitting ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  <span>Processing...</span>
-                </>
-              ) : (
-                <>
-                  <span>Simpan Perubahan</span>
-                </>
-              )}
-            </Button>
-          </form>
-        </Form>
-      </section>
-    </div>
+          <Button
+            type="submit"
+            disabled={isSubmitting || isLoading}
+            className="mt-8"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <span>Menyimpan...</span>
+              </>
+            ) : (
+              'Simpan Perubahan'
+            )}
+          </Button>
+        </form>
+      </Form>
+    </section>
   )
 }

--- a/src/modules/AccountSettings/SettingOg/SimpleMode.tsx
+++ b/src/modules/AccountSettings/SettingOg/SimpleMode.tsx
@@ -117,63 +117,57 @@ export default function SimpleMode({
   }, [existingOg])
 
   return (
-    <div className="w-full flex flex-col space-y-8 lg:flex-row lg:space-x-12 lg:space-y-0 mt-4">
-      <section className="flex-1 lg:max-w-2xl">
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-            <div className="space-y-2">
-              <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                Pilih warna latar
-              </label>
-              <GradientSelection
-                activeGradient={activeGradient}
-                onClick={handleClickGradient}
-              />
-            </div>
-            <FormField
-              control={form.control}
-              name="textOgPublik"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Teks untuk OG Image laman publik</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="Teks untuk OG Image laman publik"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="lg:max-w-2xl">
+        <div className="space-y-2">
+          <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+            Pilih warna latar
+          </label>
+          <GradientSelection
+            activeGradient={activeGradient}
+            onClick={handleClickGradient}
+          />
+        </div>
+        <FormField
+          control={form.control}
+          name="textOgPublik"
+          render={({ field }) => (
+            <FormItem className="mt-6">
+              <FormLabel>Teks untuk OG Image laman publik</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="Teks untuk OG Image laman publik"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-            <div className="flex gap-2 items-center">
-              <Button asChild type="button" variant="secondary">
-                <a
-                  href={`${BASEURL}/api/og?type=custom-user&slug=irfan-maulana&theme=${activeGradient}&text=${watchTextOgPublik}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Preview
-                  <MoveUpRight className="h-4 w-4" />
-                </a>
-              </Button>
-              <Button type="submit" disabled={isSubmitting || isLoading}>
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    <span>Processing...</span>
-                  </>
-                ) : (
-                  <>
-                    <span>Simpan Perubahan</span>
-                  </>
-                )}
-              </Button>
-            </div>
-          </form>
-        </Form>
-      </section>
-    </div>
+        <div className="mt-8 flex gap-2 flex-col sm:flex-row sm:items-center">
+          <Button asChild type="button" variant="secondary">
+            <a
+              href={`${BASEURL}/api/og?type=custom-user&slug=irfan-maulana&theme=${activeGradient}&text=${watchTextOgPublik}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Preview
+              <MoveUpRight className="h-4 w-4" />
+            </a>
+          </Button>
+          <Button type="submit" disabled={isSubmitting || isLoading}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin shrink-0" />
+                <span>Menyimpan...</span>
+              </>
+            ) : (
+              'Simpan Perubahan'
+            )}
+          </Button>
+        </div>
+      </form>
+    </Form>
   )
 }


### PR DESCRIPTION
## Description

This PR attempts to solve styling inconsistency issues across Settings pages (`/account/settings`, `/account/settings/og-image`, `/account/settings/notification`), as well as fix stylings issues that appears mostly on smaller screens. The styling will follow the styling on `/account/settings/notification` page.

<img width="175" alt="Screenshot 2023-10-14 at 21 07 03" src="https://github.com/mazipan/tanyaaja/assets/128473060/6fc805bf-dd9c-488c-9ebd-b29ba87cbae0">
<img width="400" alt="Screenshot 2023-10-14 at 21 08 04" src="https://github.com/mazipan/tanyaaja/assets/128473060/5aeb33fe-ceed-4497-b7a4-67a9da7472cc">

`/account/settings` page

<img width="175" alt="Screenshot 2023-10-14 at 21 01 47" src="https://github.com/mazipan/tanyaaja/assets/128473060/4fb4d07c-d5e2-4e0e-b86e-065ee6807e37">
<img width="400" alt="Screenshot 2023-10-14 at 21 08 16" src="https://github.com/mazipan/tanyaaja/assets/128473060/e6efb69e-4b0c-4e54-b2bf-c9a6f968546b">

`/account/settings/og-image` page (tab "Mode Sederhana")


<img width="175" alt="Screenshot 2023-10-14 at 21 02 24" src="https://github.com/mazipan/tanyaaja/assets/128473060/e209f8e2-c9a2-481e-86af-409005b4ee6d">
<img width="400" alt="Screenshot 2023-10-14 at 21 08 28" src="https://github.com/mazipan/tanyaaja/assets/128473060/153a5903-2268-4ccd-b723-925d2ac23250">

`/account/settings/og-image` page (tab "Mode Rumit")


Other than that, I also made several changes:
- Add loading spinner to the submit button on Notification page
- Replace "Processing..." label to "Menyimpan..." on button loading for language consistency
- Center align question card title with its toggler button and add gap between them to make it more readable when title fit the wrapper size as shown below:
<img width="175" alt="Screenshot 2023-10-14 at 20 07 12" src="https://github.com/mazipan/tanyaaja/assets/128473060/006ed614-3c5a-41a2-a6cc-1a52d41e027e">
