### PR TITLE
FEAT: Add Confirm Dialog Before Mark as Done

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -198,6 +198,16 @@ export const patchQuestionAsDone = async (
       },
     },
   )
+
+  /**
+   * fetch needs to be rejected manually to trigger react-query error
+   * @see https://tanstack.com/query/v4/docs/react/guides/query-functions#usage-with-fetch-and-other-clients-that-do-not-throw-by-default
+   */
+  if (!rawRes.ok) {
+    const error = await rawRes.json()
+    throw new Error(error.message)
+  }
+
   return rawRes.json()
 }
 

--- a/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
@@ -1,12 +1,25 @@
 'use client'
 
 import { useState } from 'react'
+import { DialogClose } from '@radix-ui/react-dialog'
+
+import { useMutation } from '@tanstack/react-query'
+import { User } from 'firebase/auth'
+import { Loader2 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { useToast } from '@/components/ui/use-toast'
 import { patchQuestionAsDone } from '@/lib/api'
 import { trackEvent } from '@/lib/firebase'
-import { Question } from '@/lib/types'
 
 import { QuestionPreviewProps } from './helpers'
 
@@ -16,50 +29,82 @@ export const ButtonAction = ({
   onOpenChange,
   onRefetch,
 }: Omit<QuestionPreviewProps, 'isOpen' | 'owner'>) => {
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+  const [isOpenDialog, setIsOpenDialog] = useState(false)
 
   const { toast } = useToast()
+  const { status, mutate } = useMutation({
+    mutationFn: (body: { uuid: string; user: User }) =>
+      patchQuestionAsDone(body.uuid, body.user),
+    onSuccess: async () => {
+      // we close the dialogs and shows the success toast
+      // after questions list has been refetched
 
-  const markAsDone = async (question: Question) => {
-    trackEvent('click mark as done')
-    if (user) {
-      try {
-        setIsSubmitting(true)
-        await patchQuestionAsDone(question.uuid, user)
+      await Promise.resolve(onRefetch())
 
-        toast({
-          title: 'Berhasil menandai pertanyaan',
-          description: `Berhasil menandai pertanyaan sebagai sudah dijawab!`,
-        })
+      setIsOpenDialog(false)
+      onOpenChange(false)
+      toast({
+        title: 'Berhasil menandai pertanyaan',
+        description: 'Berhasil menandai pertanyaan sebagai sudah dijawab!',
+      })
+    },
+    onError: () => {
+      toast({
+        title: 'Gagal menyimpan perubahan',
+        description:
+          'Gagal saat mencoba menandai pertanyaan sebagai sudah dijawab, coba sesaat lagi!',
+      })
+    },
+  })
 
-        setIsSubmitting(false)
-        onRefetch?.()
-        setTimeout(() => {
-          onOpenChange(false)
-        }, 500)
-      } catch (error) {
-        setIsSubmitting(false)
-        toast({
-          title: 'Gagal menyimpan perubahan',
-          description: `Gagal saat mencoba menandai pertanyaan sebagai sudah dijawab, coba sesaat lagi!`,
-        })
-      }
+  const markAsDone = () => {
+    if (question && user) {
+      trackEvent('click mark as done')
+      mutate({ uuid: question.uuid, user })
     }
   }
 
   return (
     <div className="flex flex-col md:flex-row gap-2">
-      <Button
-        type="button"
-        disabled={isSubmitting}
-        onClick={() => {
-          if (question) {
-            markAsDone(question)
+      <Dialog
+        open={isOpenDialog}
+        onOpenChange={(state) => {
+          // to ensure dialog only opens when a question exists
+          // and cannot be closed when mutation is loading
+          if (question && status !== 'loading') {
+            setIsOpenDialog(state)
           }
         }}
       >
-        Tandai sudah dijawab
-      </Button>
+        <DialogTrigger asChild>
+          <Button type="button">Tandai sudah dijawab</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Tandai pertanyaan sudah dijawab?</DialogTitle>
+            <DialogDescription>
+              Pertanyaan yang sudah dijawab tidak dapat dibatalkan.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="ghost">
+                Batal
+              </Button>
+            </DialogClose>
+            <Button type="button" onClick={markAsDone}>
+              {status === 'loading' ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin shrink-0" />
+                  <span>Menandai...</span>
+                </>
+              ) : (
+                'Tandai sudah dijawab'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
Closes #69 

## Description
Showing confirmation dialog before marking a question as done
<img width="438" alt="Screenshot 2023-10-15 at 19 17 28" src="https://github.com/mazipan/tanyaaja/assets/128473060/54e907c0-49f9-4916-a207-93560cfdb933">
