### PR TITLE
FEAT: Create a Wrapper for Fetch

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,7 +10,7 @@ import {
   UserProfile,
 } from './types'
 import { CreateCustomOgArgs } from './types'
-import { DEFAULT_AVATAR } from './utils'
+import { DEFAULT_AVATAR, httpClient } from './utils'
 
 export const BASEURL = `${process.env.NEXT_PUBLIC_BASE_URL}`
 
@@ -188,7 +188,7 @@ export const patchQuestionAsDone = async (
 ): Promise<{ message: string }> => {
   const token = await user.getIdToken()
 
-  const rawRes = await fetch(
+  const rawRes = await httpClient(
     `${BASEURL}/api/private/question/mark-done/${uuid}`,
     {
       method: 'PATCH',
@@ -198,15 +198,6 @@ export const patchQuestionAsDone = async (
       },
     },
   )
-
-  /**
-   * fetch needs to be rejected manually to trigger react-query error
-   * @see https://tanstack.com/query/v4/docs/react/guides/query-functions#usage-with-fetch-and-other-clients-that-do-not-throw-by-default
-   */
-  if (!rawRes.ok) {
-    const error = await rawRes.json()
-    throw new Error(error.message)
-  }
 
   return rawRes.json()
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -159,3 +159,20 @@ export function generateNanoId(size = 7) {
 
   return nanoid(size)
 }
+
+export function httpClient(input: RequestInfo | URL, init?: RequestInit) {
+  const promise = new Promise<Response>(async (resolve, reject) => {
+    try {
+      const response = await fetch(input, init)
+      if (response.ok) {
+        resolve(response)
+      } else {
+        reject(response)
+      }
+    } catch (error) {
+      reject(error)
+    }
+  })
+
+  return promise
+}

--- a/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
@@ -92,7 +92,11 @@ export const ButtonAction = ({
                 Batal
               </Button>
             </DialogClose>
-            <Button type="button" onClick={markAsDone}>
+            <Button
+              type="button"
+              onClick={markAsDone}
+              disabled={status === 'loading'}
+            >
               {status === 'loading' ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin shrink-0" />


### PR DESCRIPTION
Closes #41 

## Description

Create a wrapper for `fetch` that throws (reject) error by default. The example of how to use it could be found [here](https://github.com/amarangganar/tanyaaja/blob/55c1f7a364801a13c816b39e1a1ff72f24daef49/src/lib/api.ts#L191C25-L191C25)