### PR TITLE
FEAT: Optimistic Query Update on Tandai Sudah Dijawab

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -28,7 +28,7 @@ export default function Account() {
     enabled: !isLoading && isLogin && !!user,
   })
 
-  const { data: dataQuestions, isLoading: isLoadingQuestions, refetch } =
+  const { data: dataQuestions, isLoading: isLoadingQuestions } =
     // @ts-ignore
     useQuestionList(user, {
       enabled: !isLoading && isLogin && !!user,
@@ -107,7 +107,6 @@ export default function Account() {
         onOpenChange={setIsOpenDialog}
         user={user}
         owner={dataOwner?.data}
-        onRefetch={refetch}
         question={selectedQuestion}
       />
     </>

--- a/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
@@ -1,114 +1,51 @@
 'use client'
 
-import { useState } from 'react'
-import { DialogClose } from '@radix-ui/react-dialog'
-
-import { useMutation } from '@tanstack/react-query'
 import { User } from 'firebase/auth'
-import { Loader2 } from 'lucide-react'
 
+import { useDialog } from '@/components/dialog/DialogStore'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
-import { useToast } from '@/components/ui/use-toast'
-import { patchQuestionAsDone } from '@/lib/api'
 import { trackEvent } from '@/lib/firebase'
+import { Question } from '@/lib/types'
 
+import { useMarkQuestionAsDone } from '../hooks/useMarkQuestionAsDone'
 import { QuestionPreviewProps } from './helpers'
 
 export const ButtonAction = ({
   question,
   user,
   onOpenChange,
-  onRefetch,
-}: Omit<QuestionPreviewProps, 'isOpen' | 'owner'>) => {
-  const [isOpenDialog, setIsOpenDialog] = useState(false)
-
-  const { toast } = useToast()
-  const { status, mutate } = useMutation({
-    mutationFn: (body: { uuid: string; user: User }) =>
-      patchQuestionAsDone(body.uuid, body.user),
-    onSuccess: async () => {
-      // we close the dialogs and shows the success toast
-      // after questions list has been refetched
-
-      await Promise.resolve(onRefetch())
-
-      setIsOpenDialog(false)
+}: Omit<QuestionPreviewProps, 'isOpen' | 'owner' | 'onRefetch'>) => {
+  const dialog = useDialog()
+  const { mutate } = useMarkQuestionAsDone({
+    onMutate: () => {
       onOpenChange(false)
-      toast({
-        title: 'Berhasil menandai pertanyaan',
-        description: 'Berhasil menandai pertanyaan sebagai sudah dijawab!',
-      })
-    },
-    onError: () => {
-      toast({
-        title: 'Gagal menyimpan perubahan',
-        description:
-          'Gagal saat mencoba menandai pertanyaan sebagai sudah dijawab, coba sesaat lagi!',
-      })
     },
   })
 
-  const markAsDone = () => {
+  const markAsDone = async (question: Question, user: User) => {
+    trackEvent('click mark as done')
+    mutate({ uuid: question.uuid, user })
+  }
+
+  const handleMarkAsDone = () => {
     if (question && user) {
-      trackEvent('click mark as done')
-      mutate({ uuid: question.uuid, user })
+      dialog({
+        title: 'Tandai pertanyaan sudah dijawab?',
+        description: 'Pertanyaan yang sudah dijawab tidak dapat dibatalkan.',
+        submitButton: {
+          label: 'Ya, Tandai',
+          variant: 'destructive',
+        },
+        onConfirm: () => markAsDone(question, user),
+      })
     }
   }
 
   return (
     <div className="flex flex-col md:flex-row gap-2">
-      <Dialog
-        open={isOpenDialog}
-        onOpenChange={(state) => {
-          // to ensure dialog only opens when a question exists
-          // and cannot be closed when mutation is loading
-          if (question && status !== 'loading') {
-            setIsOpenDialog(state)
-          }
-        }}
-      >
-        <DialogTrigger asChild>
-          <Button type="button">Tandai sudah dijawab</Button>
-        </DialogTrigger>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Tandai pertanyaan sudah dijawab?</DialogTitle>
-            <DialogDescription>
-              Pertanyaan yang sudah dijawab tidak dapat dibatalkan.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button type="button" variant="ghost">
-                Batal
-              </Button>
-            </DialogClose>
-            <Button
-              type="button"
-              onClick={markAsDone}
-              disabled={status === 'loading'}
-            >
-              {status === 'loading' ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin shrink-0" />
-                  <span>Menandai...</span>
-                </>
-              ) : (
-                'Tandai sudah dijawab'
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <Button type="button" onClick={handleMarkAsDone}>
+        Tandai sudah dijawab
+      </Button>
     </div>
   )
 }

--- a/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
@@ -14,7 +14,7 @@ export const ButtonAction = ({
   question,
   user,
   onOpenChange,
-}: Omit<QuestionPreviewProps, 'isOpen' | 'owner' | 'onRefetch'>) => {
+}: Omit<QuestionPreviewProps, 'isOpen' | 'owner'>) => {
   const dialog = useDialog()
   const { mutate } = useMarkQuestionAsDone({
     onMutate: () => {
@@ -31,9 +31,10 @@ export const ButtonAction = ({
     if (question && user) {
       dialog({
         title: 'Tandai pertanyaan sudah dijawab?',
-        description: 'Pertanyaan yang sudah dijawab akan menghilang dari daftar pertanyaan Anda dan tidak dapat dikembalikan. Apakah Anda yakin ingin melanjutkan aksi ini?',
+        description:
+          'Pertanyaan yang sudah dijawab akan menghilang dari daftar pertanyaan Anda dan tidak dapat dikembalikan. Apakah Anda yakin ingin melanjutkan aksi ini?',
         submitButton: {
-          label: 'Ya, Tandai',
+          label: 'Ya, Tandai Sudah Dijawab',
           variant: 'destructive',
         },
         onConfirm: () => markAsDone(question, user),

--- a/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/ButtonAction.tsx
@@ -31,7 +31,7 @@ export const ButtonAction = ({
     if (question && user) {
       dialog({
         title: 'Tandai pertanyaan sudah dijawab?',
-        description: 'Pertanyaan yang sudah dijawab tidak dapat dibatalkan.',
+        description: 'Pertanyaan yang sudah dijawab akan menghilang dari daftar pertanyaan Anda dan tidak dapat dikembalikan. Apakah Anda yakin ingin melanjutkan aksi ini?',
         submitButton: {
           label: 'Ya, Tandai',
           variant: 'destructive',

--- a/src/modules/AccountSettings/QuestionPreview/QuestionDialog.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/QuestionDialog.tsx
@@ -15,7 +15,6 @@ export const QuestionDialog = ({
   user,
   isOpen,
   onOpenChange,
-  onRefetch,
   owner,
 }: QuestionPreviewProps) => {
   return (
@@ -32,7 +31,6 @@ export const QuestionDialog = ({
             question={question}
             user={user}
             onOpenChange={onOpenChange}
-            onRefetch={onRefetch}
           />
         </DialogFooter>
       </DialogContent>

--- a/src/modules/AccountSettings/QuestionPreview/QuestionResponsive.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/QuestionResponsive.tsx
@@ -11,7 +11,6 @@ export const QuestionResponsive = ({
   owner,
   isOpen,
   onOpenChange,
-  onRefetch,
 }: QuestionPreviewProps) => {
   const isMd = useMediaQuery('(min-width: 768px)')
 
@@ -23,7 +22,6 @@ export const QuestionResponsive = ({
           onOpenChange={onOpenChange}
           user={user}
           owner={owner}
-          onRefetch={onRefetch}
           question={question}
         />
       ) : (
@@ -32,7 +30,6 @@ export const QuestionResponsive = ({
           onOpenChange={onOpenChange}
           user={user}
           owner={owner}
-          onRefetch={onRefetch}
           question={question}
         />
       )}

--- a/src/modules/AccountSettings/QuestionPreview/QuestionSheet.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/QuestionSheet.tsx
@@ -15,7 +15,6 @@ export const QuestionSheet = ({
   user,
   isOpen,
   onOpenChange,
-  onRefetch,
   owner,
 }: QuestionPreviewProps) => {
   return (
@@ -32,7 +31,6 @@ export const QuestionSheet = ({
             question={question}
             user={user}
             onOpenChange={onOpenChange}
-            onRefetch={onRefetch}
           />
         </SheetFooter>
       </SheetContent>

--- a/src/modules/AccountSettings/QuestionPreview/helpers.tsx
+++ b/src/modules/AccountSettings/QuestionPreview/helpers.tsx
@@ -8,5 +8,4 @@ export interface QuestionPreviewProps {
   owner: UserProfile | null | undefined
   onOpenChange: (open: boolean) => void
   isOpen: boolean
-  onRefetch: () => void
 }

--- a/src/modules/AccountSettings/hooks/useMarkQuestionAsDone.ts
+++ b/src/modules/AccountSettings/hooks/useMarkQuestionAsDone.ts
@@ -1,0 +1,68 @@
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { User } from 'firebase/auth'
+
+import { toast } from '@/components/ui/use-toast'
+import { patchQuestionAsDone } from '@/lib/api'
+import { Question } from '@/lib/types'
+
+export const useMarkQuestionAsDone = <
+  TData = unknown,
+  TError = unknown,
+  TContext = unknown,
+>({
+  onMutate,
+}: Pick<
+  UseMutationOptions<TData, TError, { uuid: string; user: User }, TContext>,
+  'onMutate'
+>) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (body: { uuid: string; user: User }) =>
+      patchQuestionAsDone(body.uuid, body.user),
+    onMutate: async (variables) => {
+      const { uuid, user } = variables
+
+      await queryClient.cancelQueries({ queryKey: ['/questions', user.uid] })
+
+      const prevQuestions = queryClient.getQueryData<{ data: Question[] }>([
+        '/questions',
+        user.uid,
+      ])
+
+      if (prevQuestions) {
+        const filteredQuestions = prevQuestions.data.filter(
+          (question) => question.uuid !== uuid,
+        )
+
+        // optimistically update questions list
+        queryClient.setQueryData<{ data: Question[] }>(
+          ['/questions', user.uid],
+          { ...prevQuestions, data: filteredQuestions },
+        )
+      }
+
+      if (typeof onMutate === 'function') {
+        onMutate(variables)
+      }
+
+      return { prevQuestions }
+    },
+    onError: (_err, { user }, context) => {
+      queryClient.setQueryData(['/questions', user.uid], context?.prevQuestions)
+
+      toast({
+        title: 'Gagal menyimpan perubahan',
+        description:
+          'Gagal saat mencoba menandai pertanyaan sebagai sudah dijawab, coba sesaat lagi!',
+      })
+    },
+    onSettled: (_data, _err, { user }) => {
+      queryClient.invalidateQueries({ queryKey: ['/questions', user.uid] })
+    },
+  })
+}


### PR DESCRIPTION
Closes #86 

## Description
Applying optimistic update when marking question as done (following this pattern: https://tanstack.com/query/v4/docs/react/guides/optimistic-updates)


## Current Tasks
- [x] Move mark as done mutation to its own custom hook `useMarkQuestionAsDone`
- [x] Close dialog `onMutate` after performing optimistic update
- [x] Remove success `toast` and loading state on button since it is now not necessary as we're applying optimistic update
- [x] Remove `refetch` and `onRefetch` props in favor of `queryClient.invalidateQueries` 
- [x] Use `dialog` manager and apply same confirm dialog design as #87 for styling consistency 
