### PR TITLE
FIX: unparsed telegram notification message

### DIFF
--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -85,12 +85,13 @@ export const sendMessageToBot = async (
 
     const requestBody = {
       chat_id: chatID,
+      parse_mode: 'MarkdownV2',
       text: `
-**📥 New Question For You**
+              *📥 New Question For You*
 
-**Question**: ${message}
+              *Question*: ${message}
 
-Kunjungi: ${BASEURL}/account`,
+              Kunjungi: ${BASEURL}/account`,
     }
 
     if (chatID) {


### PR DESCRIPTION
Closes #64 

## Description
Fix unformatted telegram notification message by adding parse attribute as a MarkdownV2.

![tele-bot](https://github.com/mazipan/tanyaaja/assets/91646397/68d98ef2-ec25-43e2-95ee-bb97d57d0686)
