### PR TITLE
FEAT: Count notion database rows

### DIFF
--- a/src/app/api/statistics/route.ts
+++ b/src/app/api/statistics/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+
+import { countDatabaseRows } from '@/lib/notion'
+
+const DB_USER = process.env.NOTION_DB_USERS_ID || ''
+
+export async function GET(request: Request) {
+  try {
+    const usersCount = await countDatabaseRows({ databaseId: DB_USER })
+
+    return NextResponse.json({
+      message: `Public statistics`,
+      data: {
+        usersCount,
+      },
+    })
+  } catch (error) {
+    console.error(request.url, error)
+    return NextResponse.json(
+      { message: 'Error while get public statistics' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -561,3 +561,26 @@ export const getQuestionsByUuidWithPagination = async ({
 
   return response
 }
+
+export const countDatabaseRows = async ({
+  databaseId,
+}: {
+  databaseId: string
+}) => {
+  let hasMore: boolean = true
+  let rowsCount: number = 0
+  let nextCursor: string | undefined = undefined
+
+  while (hasMore) {
+    const response = await notion.databases.query({
+      database_id: databaseId,
+      start_cursor: nextCursor,
+    })
+
+    hasMore = response.has_more
+    nextCursor = response.next_cursor as string
+    rowsCount += response.results.length
+  }
+
+  return rowsCount
+}


### PR DESCRIPTION
Half-Closes (https://github.com/mazipan/tanyaaja/issues/88)

## Description

There is no out of the box that Notion provided to get the Database count. The closest endpoint to get the Rows count is [Query a Database](https://developers.notion.com/reference/post-database-query).
This is not optimal since we need to do a loop, but I cannot find any other solution. So if it's accepted, in the future we need to implement a Cache.

```
GET {{base_url}}/api/statistics

{
    "message": "Public statistics",
    "data": {
        "usersCount": 128
    }
}
```