### PR TITLE
FEAT: add API Key to access some APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # This is the base url from your app
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_API_KEY=
 
 # Get this env from Firebase
 NEXT_PUBLIC_FIREBASE_API_KEY=

--- a/next.config.js
+++ b/next.config.js
@@ -86,6 +86,9 @@ const nextConfig = {
       },
     ]
   },
+  env: {
+    NEXT_API_KEY: process.env.NEXT_API_KEY,
+  },
 }
 
 module.exports = nextConfig

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,7 @@ import { User } from 'firebase/auth'
 
 import { UpdateItem } from './telegram'
 import {
+  CreateCustomOgArgs,
   CreateNotifChannelArgs,
   CustomOg,
   IRequestPublicUserList,
@@ -12,10 +13,10 @@ import {
   UpdateUserArgs,
   UserProfile,
 } from './types'
-import { CreateCustomOgArgs } from './types'
 import { DEFAULT_AVATAR, httpClient } from './utils'
 
 export const BASEURL = `${process.env.NEXT_PUBLIC_BASE_URL}`
+export const API_KEY = `${process.env.NEXT_API_KEY}`
 
 export const getExistingUser = async (
   user: User,
@@ -28,6 +29,7 @@ export const getExistingUser = async (
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
       next: {
@@ -55,6 +57,7 @@ export const getPublicOwnerUser = async (
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
     },
     next: {
       tags: ['user-by-slug', slug],
@@ -79,6 +82,7 @@ export const checkTheSlugOwner = async (
       }),
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
     },
@@ -102,6 +106,7 @@ export const postAddUser = async (
     }),
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
       Authorization: token,
     },
   })
@@ -127,6 +132,7 @@ export const patchUpdateUser = async (
     }),
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
       Authorization: token,
     },
   })
@@ -139,6 +145,7 @@ export const patchHit = async (slug: string): Promise<{ message: string }> => {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
     },
   })
   return rawRes.json()
@@ -158,6 +165,7 @@ export const postSendQuestion = async (
     }),
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
     },
   })
   return rawRes.json()
@@ -174,6 +182,7 @@ export const getAllQuestions = async (
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
       next: {
@@ -197,6 +206,7 @@ export const patchQuestionAsDone = async (
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
     },
@@ -221,6 +231,7 @@ export const patchQuestionAsPublicOrPrivate = async (
       }),
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
     },
@@ -235,6 +246,7 @@ export const getQuestionDetail = async (
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
     },
     next: {
       tags: ['q-by-uuid', uuid],
@@ -256,6 +268,7 @@ export const destroyActiveSession = async (
     }),
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
       Authorization: token,
     },
   })
@@ -270,6 +283,7 @@ export const getAllPublicUsersForSiteMap = async (): Promise<{
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
     },
     next: {
       tags: ['public-users'],
@@ -290,6 +304,7 @@ export const getAllPublicUsers = async ({
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
       },
       next: {
         tags: ['public-users'],
@@ -307,6 +322,7 @@ export const getPublicCustomOg = async (
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
     },
     next: {
       tags: [`custom-og-by-slug-${slug}`],
@@ -327,6 +343,7 @@ export const getExistingCustomOg = async (
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
       next: {
@@ -357,6 +374,7 @@ export const postAddNewCustomOg = async (
     }),
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
       Authorization: token,
     },
   })
@@ -383,6 +401,7 @@ export const patchUpdateCustomOg = async (
     }),
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
       Authorization: token,
     },
   })
@@ -401,6 +420,7 @@ export const getExistingChannelNotif = async (
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
       next: {
@@ -428,6 +448,7 @@ export const postAddNewChannelNotif = async (
     }),
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
       Authorization: token,
     },
   })
@@ -451,6 +472,7 @@ export const patchUpdateChannelNotif = async (
     }),
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
       Authorization: token,
     },
   })
@@ -470,6 +492,7 @@ export const getCheckChatId = async (
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
       next: {
@@ -498,6 +521,7 @@ export const getAllQuestionsWithPagination = async ({
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        'X-API-KEY': API_KEY,
         Authorization: token,
       },
       next: {
@@ -516,6 +540,7 @@ export const getPublicStatistics = async (): Promise<{
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
+      'X-API-KEY': API_KEY,
     },
     next: {
       tags: ['public-stats'],

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,17 @@
+import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(_: NextRequest, __: NextResponse) {
+  const headerInstance = headers()
+  const apiKey = headerInstance.get('X-API-KEY')
+  if (apiKey !== process.env.NEXT_API_KEY) {
+    return NextResponse.json(
+      { message: 'Can not found the API KEY' },
+      { status: 401 },
+    )
+  }
+}
+
+export const config = {
+  matcher: '/api/private/question/:path*',
+}


### PR DESCRIPTION
Closes #34 

## Description
Add the API key to the env variable, make sure the Server (by default can read) and Client can read that env variable, and create a middleware so that the function can run on specific or whole APIs (for initialization the function will be run on the `/api/private/question/*`).

## Current Tasks
- [x] Add new env API_KEY
- [x] Passing the key in the header request
- [x] Read the key, make sure it's match with our env value
- [ ] I can rotate the value when abuse happens, ideally it happened in the runtime, but if it's hard then we can trigger deployment

## Asks
- I don't really understand how to implement the last part mas, and I'm just wondering what the conditions are for someone to abuse our API?